### PR TITLE
Remove epitope requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ configure-dms-viz \
 
 **Optional configuration arguments**
 
-- `--metric-name` <metric_name>: The name that should show up for your metric in the plot. This let's you customize the names of your columns in your visualization. For example, if your metric column is called `escape_mean` you can rename it to `Escape` for the visualization.
+- `--condition` <condition_column>: If there are multiple measurements per mutation, the name of the column that contains that condition distinguishing these measurements.
+- `--metric-name` <metric_name>: The name that will show up for your metric in the plot. This let's you customize the names of your columns in your visualization. For example, if your metric column is called `escape_mean` you can rename it to `Escape` for the visualization.
+- `--conditon_name` <condition_name>: The name that will show up for your condition column in the title of the plot legend. For example, if your condition column is 'epitope', you might rename it to be capilized as 'Epitope' in the legend title.
 - `--join-data` <join_data_csv>: A CSV file with data to join to the visualization data. This data can then be used in the visualization tooltips or filters. [See details below](#input-data-format) for formatting requirements.
 - `--tooltip-cols` <column_names>: A dictionary that establishes the columns that you want to show up in the tooltip in the visualization (i.e. `"{'times_seen': '# Obsv', 'effect': 'Func Eff.'}"`).
 - `--filter-cols` <column_names>: A dictionary that establishes the columns that you want to use as filters in the visualization (i.e. `"{'effect': 'Functional Effect', 'times_seen': 'Times Seen'}"`).
@@ -102,10 +104,10 @@ configure-dms-viz \
 The main inputs for `configure_dms_viz` include the following example files located in the [tests directory](tests/sars2/):
 
 1. An [**input CSV**](tests/sars2/escape/): Example CSV files containing site- and mutation-level data to visualize on a protein structure can be found in the `tests/sars2/escape` directory. The CSV must contain the following columns in addition to the specified _`metric_column`_:
-   - `site` or `reference_site`: These will be the sites that show up on the x-axis of the visualization
-   - `wildtype`: The wildtype amino acid at a given reference site
-   - `mutant`: The mutant amino acid for a given measurement
-   - `epitope`: If there are multiple measurements for the same site (i.e. multiple epitopes), a unique string deliniating these
+   - `site` or `reference_site`: These will be the sites that show up on the x-axis of the visualization.
+   - `wildtype`: The wildtype amino acid at a given reference site.
+   - `mutant`: The mutant amino acid for a given measurement.
+   - `condition`: _Optionally_, if there are multiple measurements for the same site (i.e. multiple epitopes), a unique string deliniating these measurements.
 2. A [**Sitemap**](tests/sars2/site_numbering_map.csv): An example sitemap, which is a CSV file containing a map between reference sites on the protein and their sequential order, can be found at `tests/sars2/site_numbering_map`.
    - `reference_site`: This must correspond to the `site` or `reference_site` column in your `input csv`.
    - `sequential_site`: This is the sequential order of the reference sites and must be a numeric column.

--- a/Snakefile
+++ b/Snakefile
@@ -47,6 +47,7 @@ rule create_viz_json:
         metric="escape_mean",
         metric_name="Escape",
         condition="epitope",
+        condition_name="Epitope",
     shell:
         """ 
         configure-dms-viz \
@@ -54,7 +55,6 @@ rule create_viz_json:
             --name {params.name} \
             --sitemap {input.sitemap_df} \
             --metric {params.metric} \
-            --condition {params.condition} \
             --structure {params.structure} \
             --metric-name {params.metric_name} \
             --output {output} \

--- a/Snakefile
+++ b/Snakefile
@@ -3,7 +3,7 @@
 # Import modules
 import json
 import pandas as pd
-from os.path import join 
+from os.path import join
 
 # Name of the virus in the tests directory
 virus = "sars2"
@@ -16,35 +16,45 @@ data_dir = f"tests/{virus}/escape"
 # Read in data for each virus
 experiments = pd.read_csv(join(virus_dir, f"experiments.csv"))
 
+
 # Target rule
 rule all:
     input:
-        join(output_dir, f"{virus}.json")
+        join(output_dir, f"{virus}.json"),
+
 
 # Create JSON files for each experiment
 rule create_viz_json:
     input:
-        escape_df = join(data_dir, "{experiment}_avg.csv"),
-        sitemap_df = join(virus_dir, "site_numbering_map.csv"),
-        functional_score_df = join(virus_dir, "muteffects_observed.csv")
+        escape_df=join(data_dir, "{experiment}_avg.csv"),
+        sitemap_df=join(virus_dir, "site_numbering_map.csv"),
+        functional_score_df=join(virus_dir, "muteffects_observed.csv"),
     output:
-        join(output_dir, "{experiment}.json")
-    params: 
-        name = lambda wildcards: wildcards.experiment,
-        structure = lambda wildcards: experiments.loc[experiments['selection'] == wildcards.experiment, 'pdb'].item(),
-        include_chains = lambda wildcards: experiments.loc[experiments['selection'] == wildcards.experiment, 'dataChains'].item(),
-        exclude_chains = lambda wildcards: experiments.loc[experiments['selection'] == wildcards.experiment, 'excludedChains'].item(),
-        filter_cols = {'effect': 'Functional Effect', 'times_seen': 'Times Seen'},
-        tooltip_cols = {'times_seen': '# Obsv', 'effect': 'Func Eff.'},
-        metric = "escape_mean",
-        metric_name = "Escape"
+        join(output_dir, "{experiment}.json"),
+    params:
+        name=lambda wildcards: wildcards.experiment,
+        structure=lambda wildcards: experiments.loc[
+            experiments["selection"] == wildcards.experiment, "pdb"
+        ].item(),
+        include_chains=lambda wildcards: experiments.loc[
+            experiments["selection"] == wildcards.experiment, "dataChains"
+        ].item(),
+        exclude_chains=lambda wildcards: experiments.loc[
+            experiments["selection"] == wildcards.experiment, "excludedChains"
+        ].item(),
+        filter_cols={"effect": "Functional Effect", "times_seen": "Times Seen"},
+        tooltip_cols={"times_seen": "# Obsv", "effect": "Func Eff."},
+        metric="escape_mean",
+        metric_name="Escape",
+        condition="epitope",
     shell:
-        """
+        """ 
         configure-dms-viz \
             --input {input.escape_df} \
             --name {params.name} \
             --sitemap {input.sitemap_df} \
             --metric {params.metric} \
+            --condition {params.condition} \
             --structure {params.structure} \
             --metric-name {params.metric_name} \
             --output {output} \
@@ -55,19 +65,21 @@ rule create_viz_json:
             --tooltip-cols "{params.tooltip_cols}"
         """
 
+
 # Combine JSON files into one
 rule combine_jsons:
     input:
-        input_files = expand(join(output_dir, "{experiment}.json"), experiment=experiments.selection.unique())
+        input_files=expand(
+            join(output_dir, "{experiment}.json"),
+            experiment=experiments.selection.unique(),
+        ),
     output:
-        output_file = join(output_dir, f"{virus}.json")
+        output_file=join(output_dir, f"{virus}.json"),
     run:
         combined_data = {}
         for input_file in input.input_files:
             with open(input_file) as f:
                 data = json.load(f)
                 combined_data.update(data)
-        with open(output.output_file, 'w') as f:
+        with open(output.output_file, "w") as f:
             json.dump(combined_data, f)
-
-

--- a/Snakefile
+++ b/Snakefile
@@ -58,6 +58,8 @@ rule create_viz_json:
             --structure {params.structure} \
             --metric-name {params.metric_name} \
             --output {output} \
+            --condition {params.condition} \
+            --condition-name {params.condition_name} \
             --join-data {input.functional_score_df} \
             --included-chains "{params.include_chains}" \
             --excluded-chains "{params.exclude_chains}" \

--- a/configure_dms_viz/configure_dms_viz.py
+++ b/configure_dms_viz/configure_dms_viz.py
@@ -67,6 +67,13 @@ def format_mutation_data(mut_metric_df, metric_col, condition_col, alphabet):
             f"Some of the wildtype or mutant amino acid names are not in the provided alphabet, i.e., {missing_amino_acids}"
         )
 
+    # Check that there is only one measurement per mutation if there isn't a condition column
+    if condition_col is None:
+        if mut_metric_df[["reference_site", "wildtype", "mutant"]].duplicated().any():
+            raise ValueError(
+                "Duplicates measurements per mutation were found in the mutation dataframe, please specify a condition column."
+            )
+
     return mut_metric_df
 
 

--- a/configure_dms_viz/configure_dms_viz.py
+++ b/configure_dms_viz/configure_dms_viz.py
@@ -6,7 +6,7 @@ from pandas.api.types import is_numeric_dtype
 
 
 # Check that the mutation data is in the correct format
-def format_mutation_data(mut_metric_df, metric_col, alphabet):
+def format_mutation_data(mut_metric_df, metric_col, condition_col, alphabet):
     """Check that the mutation data is in the correct format.
 
     This data should be a pandas.DataFrame with the following columns:
@@ -14,7 +14,7 @@ def format_mutation_data(mut_metric_df, metric_col, alphabet):
     - wildtype: The wildtype amino acid at the site
     - mutant: The mutant amino acid at the site
     - metric_col: The metric to visualize
-    - epitope: The epitope the mutation is in
+    - condition_col: The condition to group on if there are multiple measurements per mutation
 
     Parameters
     ----------
@@ -22,6 +22,8 @@ def format_mutation_data(mut_metric_df, metric_col, alphabet):
         A dataframe containig site- and mutation-level data for visualization.
     metric_col: str
         The name of the column the contains the metric for visualization.
+    condition_col: str
+        The name of the column the contains the condition if there are multiple measurements per mutation
     alphabet: list
         A list of the amino acid names correspoinding to the mutagenized residues.
 
@@ -46,7 +48,7 @@ def format_mutation_data(mut_metric_df, metric_col, alphabet):
         "wildtype",
         "mutant",
         metric_col,
-        "epitope",
+        condition_col,
     } - set(mut_metric_df.columns)
     if missing_mutation_columns:
         raise ValueError(
@@ -159,7 +161,7 @@ def join_additional_data(mut_metric_df, join_data):
     - mutant: The mutant amino acid at the site
 
     *Note that there currently this data should apply to all site and should
-    be identical between epitopes or conditions. Otherwise, there will be an
+    be identical between conditions. Otherwise, there will be an
     errror about duplicate data.*
 
     Parameters
@@ -296,12 +298,14 @@ def check_tooltip_columns(mut_metric_df, tooltip_cols):
 def make_experiment_dictionary(
     mut_metric_df,
     metric_col,
+    condition_col,
     sitemap_df,
     structure,
     join_data=None,
     filter_cols=None,
     tooltip_cols=None,
     metric_name=None,
+    condition_name=None,
     included_chains="polymer",
     excluded_chains="none",
     alphabet="RKHDEQNSTYWFAILMVGPC-*",
@@ -316,6 +320,8 @@ def make_experiment_dictionary(
         A dataframe containig site- and mutation-level data for visualization.
     metric_col: str
         The name of the column the contains the metric for visualization.
+    condition_col: str
+        The name of the column the contains the condition if there are multiple measurements per mutation.
     sitemap_df: pandas.DataFrame
         A dataframe mapping sequential sites to reference sites to protein sites.
     structure: str
@@ -323,7 +329,7 @@ def make_experiment_dictionary(
     metric_name: str or None
         Rename the metric column to this name if desired. This name shows up in the plot.
     join_data: list or None
-        A list of pandas.dataFrames to join to the main dataframe by mutation/epitope.
+        A list of pandas.dataFrames to join to the main dataframe by mutation/condition.
     filter_cols: dict or None
         A dictionary of column names and formatted names to designate as filters.
     tooltip_cols: dict or None
@@ -335,7 +341,7 @@ def make_experiment_dictionary(
     alphabet: str
         The amino acid labels in the order the should be displayed on the heatmap.
     colors: list
-        A list of colors that will be used for each epitope in the experiment.
+        A list of colors that will be used for each condition in the experiment.
 
     Returns
     -------
@@ -344,13 +350,15 @@ def make_experiment_dictionary(
     """
 
     # Check that the necessary columns are present in the mut_metric dataframe and format
-    mut_metric_df = format_mutation_data(mut_metric_df, metric_col, alphabet)
+    mut_metric_df = format_mutation_data(
+        mut_metric_df, metric_col, condition_col, alphabet
+    )
 
     # Check that the necessary columns are present in the sitemap dataframe and format
     sitemap_df = format_sitemap_data(sitemap_df, mut_metric_df, included_chains)
 
     # Keep track of the required columns to cut down on the final total data size
-    cols_to_keep = ["reference_site", "wildtype", "mutant", metric_col, "epitope"]
+    cols_to_keep = ["reference_site", "wildtype", "mutant", metric_col, condition_col]
 
     # Join the additional data to the main dataframe if there is any
     if join_data:
@@ -377,30 +385,36 @@ def make_experiment_dictionary(
     else:
         pdb = structure
 
-    # Get a list of the epitopes and map these to the colors
-    epitopes = list(set(mut_metric_df.epitope))
-    if len(epitopes) > len(colors):
+    # Get a list of the conditions and map these to the colors
+    conditions = list(set(mut_metric_df[condition_col]))
+    if len(conditions) > len(colors):
         raise ValueError(
-            f"There are {len(epitopes)} epitopes, but only {len(colors)} color(s) specified. Please specify more colors."
+            f"There are {len(conditions)} conditions, but only {len(colors)} color(s) specified. Please specify more colors."
         )
-    epitope_colors = {epitope: colors[i] for i, epitope in enumerate(epitopes)}
+    condition_colors = {condition: colors[i] for i, condition in enumerate(conditions)}
 
     # Rename the metric column to the metric name
     if metric_name:
         mut_metric_df = mut_metric_df.rename(columns={metric_col: metric_name})
         metric_col = metric_name
 
+    # Rename the condition column to the condition name
+    if condition_name:
+        mut_metric_df = mut_metric_df.rename(columns={condition_col: condition_name})
+        condition_col = condition_name
+
     # Make a dictionary holding the experiment data
     experiment_dict = {
         "mut_metric_df": json.loads(mut_metric_df.to_json(orient="records")),
         "metric_col": metric_col,
+        "condition_col": condition_col,
         "sitemap": sitemap_df.set_index("reference_site").to_dict(orient="index"),
         "alphabet": [aa for aa in alphabet],
         "pdb": pdb,
         "dataChains": included_chains.split(" "),
         "excludeChains": excluded_chains.split(" "),
-        "epitopes": epitopes,
-        "epitope_colors": epitope_colors,
+        "conditions": conditions,
+        "condition_colors": condition_colors,
         "filter_cols": filter_cols,
         "tooltip_cols": tooltip_cols,
     }
@@ -450,7 +464,13 @@ class DictParamType(click.ParamType):
     "--metric",
     type=str,
     required=True,
-    help="The name of the column the contains the metric for visualization.",
+    help="The name of the column that contains the metric for visualization.",
+)
+@click.option(
+    "--condition",
+    type=str,
+    required=True,
+    help="The name of the column that contains the condition to group on if there are multiple measurements per experiment.",
 )
 @click.option(
     "--structure",
@@ -476,6 +496,13 @@ class DictParamType(click.ParamType):
     required=False,
     default=None,
     help="Optionally, the name that should show up for your metric in the plot.",
+)
+@click.option(
+    "--condition-name",
+    type=str,
+    required=False,
+    default=None,
+    help="Optionally, the name that should show up for your condition column in the plot.",
 )
 @click.option(
     "--filter-cols",
@@ -524,16 +551,18 @@ class DictParamType(click.ParamType):
     type=ListParamType(),
     required=False,
     default=["#0072B2", "#CC79A7", "#4C3549", "#009E73"],
-    help='A list of colors to use for the epitopes in the visualization. Example: "#0072B2, #CC79A7, #4C3549, #009E73"',
+    help='A list of colors to use for the conditions in the visualization. Example: "#0072B2, #CC79A7, #4C3549, #009E73"',
 )
 def cli(
     input,
     sitemap,
     metric,
+    condition,
     structure,
     name,
     output,
     metric_name,
+    condition_name,
     filter_cols,
     tooltip_cols,
     join_data,
@@ -568,12 +597,14 @@ def cli(
     experiment_dict = make_experiment_dictionary(
         mut_metric_df,
         metric,
+        condition,
         sitemap_df,
         structure,
         join_data_dfs,
         filter_cols,
         tooltip_cols,
         metric_name,
+        condition_name,
         included_chains,
         excluded_chains,
         alphabet,


### PR DESCRIPTION
This pull request increases the flexibility of the data handling process by removing the mandatory 'epitope' column. This change improves adaptability to datasets with varying formats.

Previously, the 'epitope' column was required for differentiating between multiple measurements for a single mutation. With this update, this need for differentiation is addressed in a more generalized manner, taking into account that datasets can have single or multiple measurements, and that those measurements might have nothing to do with ‘Epitopes’. 

Specifically, for datasets with only a single measurement per mutation, it is no longer necessary to include a distinguishing column. If multiple measurements exist per mutation, users can now specify any column in their dataset to serve as the 'condition' column using the `--condition` flag. The users can also name the 'condition' title in the legend as they wish using the `--condition_name` flag, further increasing the customization level and adaptability to various datasets.
