### PR TITLE
Sort the condition column values to preserve order

### DIFF
--- a/configure_dms_viz/configure_dms_viz.py
+++ b/configure_dms_viz/configure_dms_viz.py
@@ -618,7 +618,7 @@ def make_experiment_dictionary(
     if colors is None:
         colors = ["#0072B2", "#CC79A7", "#4C3549", "#009E73"]
     if condition_col:
-        conditions = list(set(mut_metric_df[condition_col]))
+        conditions = sorted(list(set(mut_metric_df[condition_col])))
         if len(conditions) > len(colors):
             raise ValueError(
                 f"There are {len(conditions)} conditions, but only {len(colors)} color(s) specified. Please specify more colors."


### PR DESCRIPTION
The random ordering is the result of using `set()` to get the unique values of the `condition` column and enumerated over the unique conditions to assign colors. I fixed it by sorting the column.